### PR TITLE
Add other networks

### DIFF
--- a/crates/wallet_compatible_derivation/src/lib.rs
+++ b/crates/wallet_compatible_derivation/src/lib.rs
@@ -70,6 +70,7 @@ pub mod prelude {
     pub(crate) use crate::derive_key_pair::*;
     pub(crate) use std::str::FromStr;
     pub(crate) use zeroize::{Zeroize, ZeroizeOnDrop};
+    pub(crate) use radix_common::network::NetworkDefinition as ScryptoNetworkDefinition;
 }
 
 pub use prelude::*;

--- a/crates/wallet_compatible_derivation/src/network_id.rs
+++ b/crates/wallet_compatible_derivation/src/network_id.rs
@@ -16,35 +16,35 @@ use crate::prelude::*;
 pub enum NetworkID {
     /// The Radix mainnet.
     #[strum(ascii_case_insensitive)]
-    Mainnet,
+    Mainnet = 0x01,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Stokenet,
+    Stokenet = 0x02,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Enkinet,
+    Enkinet = 0x21,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Hammunet,
+    Hammunet = 0x22,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Dumunet,
+    Dumunet = 0x25,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Mardunet,
+    Mardunet = 0x24,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Gilganet,
+    Gilganet = 0x20,
 
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
-    Nergalnet
+    Nergalnet = 0x23
 }
 impl NetworkID {
     /// Returns a collection of all networks this software support.

--- a/crates/wallet_compatible_derivation/src/network_id.rs
+++ b/crates/wallet_compatible_derivation/src/network_id.rs
@@ -1,5 +1,6 @@
 use radix_common::prelude::NetworkDefinition;
 use strum_macros::{Display, EnumString};
+use std::borrow::Cow;
 
 use crate::prelude::*;
 
@@ -10,7 +11,7 @@ use crate::prelude::*;
 ///
 /// [node]: https://github.com/radixdlt/babylon-node/blob/main/common/src/main/java/com/radixdlt/networks/Network.java#L82-L98
 #[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumString, Display, enum_iterator::Sequence,
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumString, Display, enum_iterator::Sequence,Copy
 )]
 pub enum NetworkID {
     /// The Radix mainnet.
@@ -20,8 +21,31 @@ pub enum NetworkID {
     /// A public facing testnet.
     #[strum(ascii_case_insensitive)]
     Stokenet,
-}
 
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Enkinet,
+
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Hammunet,
+
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Dumunet,
+
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Mardunet,
+
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Gilganet,
+
+    /// A public facing testnet.
+    #[strum(ascii_case_insensitive)]
+    Nergalnet
+}
 impl NetworkID {
     /// Returns a collection of all networks this software support.
     ///
@@ -32,6 +56,17 @@ impl NetworkID {
     /// [node]: https://github.com/radixdlt/babylon-node/blob/main/common/src/main/java/com/radixdlt/networks/Network.java#L82-L98
     pub fn all() -> Vec<NetworkID> {
         enum_iterator::all::<NetworkID>().collect::<Vec<_>>()
+    }
+
+    /// The raw representation of this network id, an `u8`.
+    pub fn discriminant(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Name, most not be changed, i.e. cannot capitalized, is used
+    /// by app to validate against Gateway
+    pub fn logical_name(&self) -> String {
+        self.network_definition().logical_name.into_owned()
     }
 }
 
@@ -46,6 +81,13 @@ impl TryFrom<HDPathComponentValue> for NetworkID {
         match value {
             1 => Ok(NetworkID::Mainnet),
             2 => Ok(NetworkID::Stokenet),
+            32 => Ok(NetworkID::Gilganet),
+            33 => Ok(NetworkID::Enkinet),
+            34 => Ok(NetworkID::Hammunet),
+            35 => Ok(NetworkID::Nergalnet),
+            36 => Ok(NetworkID::Mardunet),
+            37 => Ok(NetworkID::Dumunet),
+
             _ => Err(Error::UnsupportedOrUnknownNetworkID(value)),
         }
     }
@@ -59,15 +101,51 @@ impl NetworkID {
         match self {
             NetworkID::Mainnet => harden(1),
             NetworkID::Stokenet => harden(2),
+            NetworkID::Enkinet =>harden(33),
+            NetworkID::Hammunet =>harden(34),
+            NetworkID::Dumunet =>harden(37),
+            NetworkID::Mardunet =>harden(36),
+            NetworkID::Gilganet =>harden(32),
+            NetworkID::Nergalnet =>harden(35),
         }
     }
 
     /// A network definition used by this library to form bech32 encoded
     /// addresses.
-    pub(crate) fn network_definition(&self) -> NetworkDefinition {
+    pub(crate) fn network_definition(&self) -> ScryptoNetworkDefinition {
         match self {
             NetworkID::Mainnet => NetworkDefinition::mainnet(),
             NetworkID::Stokenet => NetworkDefinition::stokenet(),
+            NetworkID::Enkinet => ScryptoNetworkDefinition {
+                id: NetworkID::Enkinet.discriminant(),
+                logical_name: Cow::Borrowed("enkinet"),
+                hrp_suffix: Cow::Borrowed("tdx_21_"),
+            },
+            NetworkID::Hammunet =>ScryptoNetworkDefinition {
+                id: NetworkID::Hammunet.discriminant(),
+                logical_name: Cow::Borrowed("hammunet"),
+                hrp_suffix: Cow::Borrowed("tdx_22_"),
+            },
+            NetworkID::Dumunet => ScryptoNetworkDefinition {
+                id: NetworkID::Dumunet.discriminant(),
+                logical_name: Cow::Borrowed("dumunet"),
+                hrp_suffix: Cow::Borrowed("tdx_25_"),
+            },
+            NetworkID::Mardunet =>ScryptoNetworkDefinition {
+                id: NetworkID::Mardunet.discriminant(),
+                logical_name: Cow::Borrowed("mardunet"),
+                hrp_suffix: Cow::Borrowed("tdx_24_"),
+            },
+            NetworkID::Gilganet => ScryptoNetworkDefinition {
+                id:  NetworkID::Gilganet.discriminant(),
+                logical_name: Cow::Borrowed("gilganet"),
+                hrp_suffix: Cow::Borrowed("tdx_32_"),
+            },
+            NetworkID::Nergalnet =>  ScryptoNetworkDefinition {
+                id:  NetworkID::Nergalnet.discriminant(),
+                logical_name: Cow::Borrowed("nergalnet"),
+                hrp_suffix: Cow::Borrowed("tdx_24_"),
+            },
         }
     }
 }


### PR DESCRIPTION
Added more networks and these are not defined in radix-common. So used the implementation logic that we have from sargon

https://github.com/radixdlt/sargon/blob/main/crates/common/network/src/network_id.rs#L168